### PR TITLE
Add standalone option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ RUN ["ln", "-s", "/opt/stellar/horizon/etc/horizon.env", "/horizon.env"]
 ADD common /opt/stellar-default/common
 ADD pubnet /opt/stellar-default/pubnet
 ADD testnet /opt/stellar-default/testnet
+ADD standalone /opt/stellar-default/standalone
 
 
 ADD start /

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The image uses the following software:
 
 To use this project successfully, you should first decide a few things:
 
-First, decide whether you want your container to be part of the public, production Stellar network (referred to as the _pubnet_) or the test network (called testnet) that we recommend you use while developing software because you need not worry about losing money on the testnet.  You'll provide either `--pubnet` or `--testnet` as a command line flag when starting the container to determine which network (and base configuration file) to use.
+First, decide whether you want your container to be part of the public, production Stellar network (referred to as the _pubnet_) or the test network (called testnet) that we recommend you use while developing software because you need not worry about losing money on the testnet. Additionally, we have added a standalone network (called standalone) which allows you to run your own private Stellar network. You'll provide either `--pubnet`, `--testnet` or `--standalone` as a command line flag when starting the container to determine which network (and base configuration file) to use.
 
 Next, you must decide whether you will use a docker volume or not.  When not using a volume, we say that the container is in _ephemeral mode_, that is, nothing will be persisted between runs of the container. _Persistent mode_ is the alternative, which should be used in the case that you need to either customize your configuration (such as to add a validation seed) or would like avoid a slow catchup to the Stellar network in the case of a crash or server restart.  We recommend persistent mode for anything besides a development or test environment.
 

--- a/standalone/core/etc/stellar-core.cfg
+++ b/standalone/core/etc/stellar-core.cfg
@@ -1,0 +1,29 @@
+# simple configuration for a standalone test "network"
+# see stellar-core_example.cfg for a description of the configuration parameters
+
+HTTP_PORT=11626
+PUBLIC_HTTP_PORT=true
+RUN_STANDALONE=true
+
+NETWORK_PASSPHRASE="Standalone Network ; February 2017"
+
+NODE_SEED="SDQVDISRYN2JXBS7ICL7QJAEKB3HWBJFP2QECXG7GZICAHBK4UNJCWK2 self"
+NODE_IS_VALIDATOR=true
+
+#DATABASE="postgresql://dbname=stellar user=postgres password=password host=localhost"
+#DATABASE="sqlite3://stellar.db"
+DATABASE="postgresql://dbname=core host=localhost user=stellar password=__PGPASS__"
+
+COMMANDS=["ll?level=debug"]
+
+FAILURE_SAFETY=0
+UNSAFE_QUORUM=true
+#The public keys of the Stellar testnet servers
+[QUORUM_SET]
+THRESHOLD_PERCENT=100
+VALIDATORS=["$self"]
+
+[HISTORY.vs]
+get="cp /tmp/stellar-core/history/vs/{0} {1}"
+put="cp {0} /tmp/stellar-core/history/vs/{1}"
+mkdir="mkdir -p /tmp/stellar-core/history/vs/{0}"

--- a/start
+++ b/start
@@ -50,6 +50,9 @@ function process_args() {
 	  --pubnet)
 	    NETWORK="pubnet"
 	    ;;
+	  --standalone)
+		NETWORK="standalone"
+		;;
 	  *)
 	    echo "Unknown container arg $ARG" >&2
 	    exit 1
@@ -67,6 +70,9 @@ function process_args() {
     ;;
 	pubnet)
     NETWORK_PASSPHRASE="Public Global Stellar Network ; September 2015"
+    ;;
+	standalone)
+    NETWORK_PASSPHRASE="Standalone Network ; February 2017"
     ;;
 	*)
 		echo "Unknown network: '$NETWORK'" >&2
@@ -182,7 +188,12 @@ function init_stellar_core() {
 	run_silent "finalize-core-config" sed -ri "s/__PGPASS__/$PGPASS/g" etc/stellar-core.cfg
 
 	start_postgres
+
 	run_silent "init-core-db" sudo -u stellar stellar-core --newdb --conf etc/stellar-core.cfg
+
+	if [ "$NETWORK" == "standalone" ]; then
+		run_silent "init-core-scp" sudo -u stellar stellar-core --forcescp --conf etc/stellar-core.cfg
+	fi
 
 	touch .quickstart-initialized
 	popd


### PR DESCRIPTION
By using the `--standalone` flag a private network will be created instead of joining the pub- or testnet.