### PR TITLE
Fix high UID causing large image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,11 +26,9 @@ RUN /install
 RUN ["mkdir", "-p", "/opt/stellar"]
 RUN ["touch", "/opt/stellar/.docker-ephemeral"]
 
-RUN [ "adduser", \
-  "--disabled-password", \
-  "--gecos", "\"\"", \
-  "--uid", "10011001", \
-  "stellar"]
+RUN useradd --uid 10011001 --home-dir /home/stellar --no-log-init stellar \
+    && mkdir -p /home/stellar \
+    && chown -R stellar:stellar /home/stellar
 
 RUN ["ln", "-s", "/opt/stellar", "/stellar"]
 RUN ["ln", "-s", "/opt/stellar/core/etc/stellar-core.cfg", "/stellar-core.cfg"]


### PR DESCRIPTION
Apparently having a high UID causes the lastlog file to become very large. 

Some more info: https://bugzilla.redhat.com/show_bug.cgi?id=771286

```
$ docker images
REPOSITORY                                    TAG                 IMAGE ID            CREATED             SIZE
stellar/quickstart                            latest              c704f9ede93d        5 minutes ago       676MB
```

I switched to using `useradd` instead of `adduser` because I don't think `adduser` supports the `--no-log-init` switch.

Fixes #13 