### PR TITLE
--standalone was not working

### DIFF
--- a/start
+++ b/start
@@ -51,8 +51,8 @@ function process_args() {
 	    NETWORK="pubnet"
 	    ;;
 	  --standalone)
-		NETWORK="standalone"
-		;;
+	    NETWORK="standalone"
+	    ;;
 	  *)
 	    echo "Unknown container arg $ARG" >&2
 	    exit 1


### PR DESCRIPTION
The start script contained extra tabs/whitespace which caused NETWORK=standalone to never be set. Instead passing --standalone to the end of a docker run command threw an unknown container arg error.

This simple formatting fix worked for me and I was able to successfully build using make and fire up a standalone container. 

Hope this helps.