### PR TITLE
Change postgresql version to 9.6

### DIFF
--- a/start
+++ b/start
@@ -7,7 +7,7 @@ export SUPHOME="$STELLAR_HOME/supervisor"
 export COREHOME="$STELLAR_HOME/core"
 export HZHOME="$STELLAR_HOME/horizon"
 
-export PGBIN="/usr/lib/postgresql/9.4/bin"
+export PGBIN="/usr/lib/postgresql/9.6/bin"
 export PGDATA="$PGHOME/data"
 export PGUSER="stellar"
 export PGPORT=5432

--- a/start
+++ b/start
@@ -233,7 +233,7 @@ function init_horizon() {
 	pushd $HZHOME
 
 	run_silent "chown-horizon" chown stellar:stellar .
-	
+
 	sed -ri \
 		-e "s/__PGPASS__/$PGPASS/g" \
 		-e "s/__NETWORK__/$NETWORK_PASSPHRASE/g" \


### PR DESCRIPTION
```
Since stellar-base Docker image was update last month, going from jessie to strecth, the postgres version is 9.6, not 9.4.
```