### PR TITLE
Explicitly disable ssl mode

### DIFF
--- a/common/horizon/etc/horizon.env
+++ b/common/horizon/etc/horizon.env
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-export DATABASE_URL="postgres://stellar:__PGPASS__@localhost/horizon"
-export STELLAR_CORE_DATABASE_URL="postgres://stellar:__PGPASS__@localhost/core"
+export DATABASE_URL="postgres://stellar:__PGPASS__@localhost/horizon?sslmode=disable"
+export STELLAR_CORE_DATABASE_URL="postgres://stellar:__PGPASS__@localhost/core?sslmode=disable"
 export STELLAR_CORE_URL="http://localhost:11626"
 export LOG_LEVEL="info"
 export INGEST="true"


### PR DESCRIPTION
Starting Horizon led to a panic with the error message 'rror: pq: SSL is not enabled on the server'.