### PR TITLE
Debian stretch updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+sudo: required
+services:
+- docker
+language: bash
+before_script: docker build -t stellar-travis .
+script:
+  - docker run --rm -it -p "8000:8000" --name stellar stellar-travis --testnet
+  - sleep 120
+  - exit 0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,14 @@
 sudo: required
 services:
 - docker
-language: bash
+env:
+  - NETWORK=testnet
+  - NETWORK=pubnet
+language: go
 before_script: docker build -t stellar-travis .
 script:
-  - docker run --rm -it -p "8000:8000" --name stellar stellar-travis --testnet
-  - sleep 120
-  - exit 0
+  - |
+    docker run --rm -d -p "8000:8000" --name stellar stellar-travis --$NETWORK
+    sleep 10 # sleep until supervisor is up
+    echo "supervisorctl tail -f stellar-core" | docker exec -i stellar sh &
+    go run travis.go

--- a/common/supervisor/etc/supervisord.conf
+++ b/common/supervisor/etc/supervisord.conf
@@ -15,7 +15,7 @@ serverurl=unix:///var/run/supervisor.sock
 
 [program:postgresql]
 user=postgres
-command=/usr/lib/postgresql/9.4/bin/postgres -D "/opt/stellar/postgresql/data" -c config_file=/opt/stellar/postgresql/etc/postgresql.conf
+command=/usr/lib/postgresql/9.6/bin/postgres -D "/opt/stellar/postgresql/data" -c config_file=/opt/stellar/postgresql/etc/postgresql.conf
 stopsignal=INT
 autostart=true
 autorestart=true

--- a/start
+++ b/start
@@ -299,7 +299,7 @@ function stop_postgres() {
 		return 0
 	fi
 
-	kill $CURRENT_POSTGRES_PID
+	killall postgres
 	# wait for postgres to die
 	while kill -0 "$CURRENT_POSTGRES_PID" &> /dev/null; do
 		sleep 0.5

--- a/start
+++ b/start
@@ -7,7 +7,7 @@ export SUPHOME="$STELLAR_HOME/supervisor"
 export COREHOME="$STELLAR_HOME/core"
 export HZHOME="$STELLAR_HOME/horizon"
 
-export PGBIN="/usr/lib/postgresql/9.4/bin"
+export PGBIN="/usr/lib/postgresql/9.6/bin"
 export PGDATA="$PGHOME/data"
 export PGUSER="stellar"
 export PGPORT=5432

--- a/travis.go
+++ b/travis.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"os"
+	"time"
+)
+
+const timeout = 1 * time.Hour
+
+type Root struct {
+	HorizonSequence int32 `json:"history_latest_ledger"`
+	CoreSequence    int32 `json:"core_latest_ledger"`
+}
+
+func main() {
+	startTime := time.Now()
+
+	for {
+		time.Sleep(10 * time.Second)
+		logLine("Waiting for Horizon to start ingesting")
+
+		if time.Since(startTime) > timeout {
+			logLine("Timeout")
+			os.Exit(-1)
+		}
+
+		resp, err := http.Get("http://localhost:8000")
+		if err != nil {
+			logLine(err)
+			continue
+		}
+
+		var root Root
+		decoder := json.NewDecoder(resp.Body)
+		err = decoder.Decode(&root)
+		if err != nil {
+			logLine(err)
+			continue
+		}
+
+		if root.HorizonSequence > 0 {
+			logLine("Horizon started ingesting!")
+			os.Exit(0)
+		}
+	}
+}
+
+func logLine(text interface{}) {
+	log.Println("\033[32;1m[test]\033[0m", text)
+}


### PR DESCRIPTION
Update image to use debian stretch, including Postgres 9.6 (instead of 9.4 in the previous version), because `stellar/base` image was updated.

Not sure why but `kill $CURRENT_POSTGRES_PID` command is not working now. I thought that maybe it's an issue with my docker installation however I experienced the same issue on travis. Changed this command to equivalent: `killall postgres`.

Added tests that start testnet/pubnet containers and wait until Horizon starts ingesting ledgers.