### PR TITLE
Add SDF nodes to PREFERRED_PEERS in testnet

### DIFF
--- a/testnet/core/etc/stellar-core.cfg
+++ b/testnet/core/etc/stellar-core.cfg
@@ -9,6 +9,13 @@ KNOWN_PEERS=[
 "core-testnet2.stellar.org",
 "core-testnet3.stellar.org"]
 
+PREFERRED_PEERS=[
+"core-testnet1.stellar.org",
+"core-testnet2.stellar.org",
+"core-testnet3.stellar.org"]
+
+PREFERRED_PEERS_ONLY=true
+
 DATABASE="postgresql://dbname=core host=localhost user=stellar password=__PGPASS__"
 UNSAFE_QUORUM=true
 FAILURE_SAFETY=1


### PR DESCRIPTION
It's impossible to sync with testnet without it (connects to pre-reset test network).