### PR TITLE
Ensured 'chown-core' is executed before 'init-core-scp' in standalone mode

### DIFF
--- a/start
+++ b/start
@@ -212,6 +212,8 @@ function init_db() {
 }
 
 function init_stellar_core() {
+	pushd $COREHOME
+	run_silent "chown-core" chown -R stellar:stellar .
 	if [ -f $COREHOME/.quickstart-initialized ]; then
 		echo "core: already initialized"
 
@@ -223,9 +225,7 @@ function init_stellar_core() {
 
 		return 0
 	fi
-	pushd $COREHOME
 
-	run_silent "chown-core" chown stellar:stellar .
 	run_silent "finalize-core-config" sed -ri "s/__PGPASS__/$PGPASS/g" etc/stellar-core.cfg
 
 	start_postgres


### PR DESCRIPTION
When running in disconnected mode the init-core-scp command would fail. This change moves the pushd and chown commands up to ensure the image works as expected when running in standalone mode.

this fixes https://github.com/stellar/docker-stellar-core-horizon/issues/122