### PR TITLE
Fixed bin file not copied

### DIFF
--- a/start
+++ b/start
@@ -153,9 +153,10 @@ function copy_defaults() {
 	if [ -d $COREHOME/etc ]; then
 		echo "stellar-core: config directory exists, skipping copy"
 	else
-		$CP /opt/stellar-default/common/core/ $COREHOME
-		$CP /opt/stellar-default/$NETWORK/core/ $COREHOME
+		$CP /opt/stellar-default/$NETWORK/core/etc $COREHOME
 	fi
+		
+    $CP /opt/stellar-default/common/core/bin $COREHOME
 
 	if [ -d $HZHOME/etc ]; then
 		echo "horizon: config directory exists, skipping copy"


### PR DESCRIPTION
If volume with stellar-core config is added (like "some-dir:/opt/stellar/core/etc"), then /opt/stellar/core/bin directory would be empty. This PR fixes that issue.