### PR TITLE
Fix standalone horizon 1.0.0

### DIFF
--- a/start
+++ b/start
@@ -43,16 +43,16 @@ function process_args() {
 	  shift
 
 
-      case "${ARG}" in
-      --testnet)
-        NETWORK="testnet"
-        ;;
-      --pubnet)
-        NETWORK="pubnet"
-    ;;
-      --standalone)
-        NETWORK="standalone"
-        ;;
+	  case "${ARG}" in
+	  --testnet)
+	    NETWORK="testnet"
+	    ;;
+	  --pubnet)
+	    NETWORK="pubnet"
+	    ;;
+	  --standalone)
+	    NETWORK="standalone"
+	    ;;
     --protocol-version)
       export PROTOCOL_VERSION="$1"
       shift

--- a/start
+++ b/start
@@ -43,18 +43,22 @@ function process_args() {
 	  shift
 
 
-	  case "${ARG}" in
-	  --testnet)
-	    NETWORK="testnet"
-	    ;;
-	  --pubnet)
-	    NETWORK="pubnet"
-	    ;;
-	  --standalone)
-	    NETWORK="standalone"
-	    ;;
+      case "${ARG}" in
+      --testnet)
+        NETWORK="testnet"
+        ;;
+      --pubnet)
+        NETWORK="pubnet"
+    ;;
+      --standalone)
+        NETWORK="standalone"
+        ;;
     --protocol-version)
       export PROTOCOL_VERSION="$1"
+      shift
+      ;;
+    --history-archive-urls)
+      export HISTORY_ARCHIVE_URLS="$1"
       shift
       ;;
     --enable-asset-stats)
@@ -82,7 +86,9 @@ function process_args() {
     export HISTORY_ARCHIVE_URLS="https://history.stellar.org/prd/core-live/core_live_001"
     ;;
 	standalone)
-    NETWORK_PASSPHRASE="Standalone Network ; February 2017"
+    export NETWORK_PASSPHRASE="Standalone Network ; February 2017"
+    # h1570ry - we'll start a webserver connected to history directory later on
+    export HISTORY_ARCHIVE_URLS="http://localhost:1570"
     ;;
 	*)
 		echo "Unknown network: '$NETWORK'" >&2
@@ -236,6 +242,12 @@ function init_stellar_core() {
 
 	if [ "$NETWORK" == "standalone" ]; then
 		run_silent "init-core-scp" sudo -u stellar stellar-core force-scp --conf etc/stellar-core.cfg
+
+		run_silent "init-history" sudo -u stellar stellar-core new-hist vs --conf $COREHOME/etc/stellar-core.cfg
+		# Start local history server
+		pushd /tmp/stellar-core/history/vs
+		python3 -m http.server 1570 &
+		popd
 	fi
 
 	touch .quickstart-initialized

--- a/start
+++ b/start
@@ -57,10 +57,6 @@ function process_args() {
       export PROTOCOL_VERSION="$1"
       shift
       ;;
-    --history-archive-urls)
-      export HISTORY_ARCHIVE_URLS="$1"
-      shift
-      ;;
     --enable-asset-stats)
       export ENABLE_ASSET_STATS="$1"
       shift

--- a/start
+++ b/start
@@ -242,7 +242,7 @@ function init_stellar_core() {
 		run_silent "init-history" sudo -u stellar stellar-core new-hist vs --conf $COREHOME/etc/stellar-core.cfg
 		# Start local history server
 		pushd /tmp/stellar-core/history/vs
-		python3 -m http.server 1570 &
+		python3 -m http.server 1570 > /dev/null 2>&1 &
 		popd
 	fi
 


### PR DESCRIPTION
Horizon 1.0.0 requires history archives to build internal ledger state. This breaks standalone mode because Stellar-Core stores history data in local file system. To solve this we start local web server that serves files from history archive.

This is a quick fix: when history is initialized using `stellar-core newhist` command the `currentLedger` value is equal `0` and makes Horizon wait for a valid, non-zero value. Because of this Horizon is able to start ingesting after 64 ledgers (when first checkpoint is created).

To fix this permanently Stellar-Core or Horizon code needs to be changed.

Close #160.