### PR TITLE
Decrease CATCHUP_RECENT in Stellar-Core config

### DIFF
--- a/pubnet/core/etc/stellar-core.cfg
+++ b/pubnet/core/etc/stellar-core.cfg
@@ -4,7 +4,7 @@ LOG_FILE_PATH=""
 
 DATABASE="postgresql://dbname=core host=localhost user=stellar password=__PGPASS__"
 NETWORK_PASSPHRASE="Public Global Stellar Network ; September 2015"
-CATCHUP_RECENT=8640
+CATCHUP_RECENT=100
 
 [HISTORY.cache]
 get="cp /opt/stellar/history-cache/{0} {1}"

--- a/testnet/core/etc/stellar-core.cfg
+++ b/testnet/core/etc/stellar-core.cfg
@@ -7,7 +7,7 @@ NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
 DATABASE="postgresql://dbname=core host=localhost user=stellar password=__PGPASS__"
 UNSAFE_QUORUM=true
 FAILURE_SAFETY=1
-CATCHUP_RECENT=8640
+CATCHUP_RECENT=100
 
 [HISTORY.cache]
 get="cp /opt/stellar/history-cache/{0} {1}"


### PR DESCRIPTION
`stellar/quickstart` image is meant to be a fast way to sync with Stellar network for development/test purposes. Downloading 8640 ledgers (12 hours) slows down the startup time. This should also fix tests that currently timeout.