### PR TITLE
Enable TAG_TESTING=1 NETWORK=pubnet tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
   - NETWORK=testnet
   - NETWORK=pubnet 
   - TAG_TESTING=1 NETWORK=testnet
-  # - TAG_TESTING=1 NETWORK=pubnet Disabled temporarily since Travis fail when running new ingestion system on pubnet
+  - TAG_TESTING=1 NETWORK=pubnet
 language: go
 script:
   - |


### PR DESCRIPTION
Tests were disabled in https://github.com/stellar/docker-stellar-core-horizon/commit/217f3a24f5847dac69fab7c23a9a423c32247c96#diff-354f30a63fb0907d4ad57269548329e3R8 because they were timing out but it was fixed in https://github.com/stellar/docker-stellar-core-horizon/commit/95ca5fe598b11fe77cfb8384977be804805a7428.