### PR TITLE
Github action to build and push docker image on tag

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -1,0 +1,23 @@
+name: Publish Docker
+
+on:
+  push:
+    tags: v*
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Get release version
+      id: get_version
+      run: echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_REF:10})
+    - name: Publish to Registry
+      uses: elgohr/Publish-Docker-Github-Action@master
+      with:
+        name: stellar/quickstart
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        dockerfile: Dockerfile.testing
+        tags: "latest,${{ env.RELEASE_VERSION }}"
+


### PR DESCRIPTION
Provided the env DOCKER_USERNAME and DOCKER_PASSWORD have been established as GitHub secrets, this Github workflow will build, tag and push the Dockerfile.testing image to dockerhub.

Note, I've got `Dockerfile.testing` here on line 21. Maintainers may wish to change this to `Dockerfile`. The contents are identical at the time of this PR, so I'm not sure what the distinction was mean to be.