### PR TITLE
Add CI job to publish docker image on merge to master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,28 @@
+version: 2.1
+
+jobs:
+  publish_docker_image:
+    docker:
+      - image: circleci/buildpack-deps:stretch
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Build and Push Docker image
+          command: |
+            echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
+            docker build -t stellar/quickstart:latest .
+            docker push stellar/quickstart:latest
+            docker build -f Dockerfile.testing -t stellar/quickstart:testing .
+            docker push stellar/quickstart:testing
+
+workflows:
+  version: 2
+
+  publish:
+    jobs:
+      - publish_docker_image:
+          filters:
+              branches:
+                only:
+                  - master


### PR DESCRIPTION
This commit adds a Circle CI job which is invoked whenever a commit is pushed to master.
The job will build and publish the `stellar/quickstart:latest` and `stellar/quickstart:testing` docker images.
We will need to include dockerhub credentials in the `DOCKER_USER` and `DOCKER_PASS` environment variables so that circle ci will have the permissions to push to the `stellar/quickstart` image repo.
