### PR TITLE
Run init-genesis-state in standalone

### DIFF
--- a/start
+++ b/start
@@ -257,13 +257,6 @@ function init_horizon() {
 	fi
 	pushd $HZHOME
 
-	# copy new horizon binary if available in custom_bin directory provided by the user
-	if [ -d /custom_bin ]; then
-		echo "horizon: copying custom horizon binary"
-		cp /custom_bin/horizon /usr/local/bin/horizon
-		chmod +x /usr/local/bin/horizon
-	fi
-
 	run_silent "chown-horizon" chown stellar:stellar .
 
 	sed -ri \

--- a/start
+++ b/start
@@ -257,6 +257,13 @@ function init_horizon() {
 	fi
 	pushd $HZHOME
 
+	# copy new horizon binary if available in custom_bin directory provided by the user
+	if [ -d /custom_bin ]; then
+		echo "horizon: copying custom horizon binary"
+		cp /custom_bin/horizon /usr/local/bin/horizon
+		chmod +x /usr/local/bin/horizon
+	fi
+
 	run_silent "chown-horizon" chown stellar:stellar .
 
 	sed -ri \
@@ -267,6 +274,10 @@ function init_horizon() {
 
 	start_postgres
 	run_silent "init-horizon-db" sudo -u stellar ./bin/horizon db init
+	if [ "$NETWORK" == "standalone" ]; then
+		# init-genesis-state command has not been released yet so ignore error and remove `|| true` later.
+		run_silent "init-genesis-state" sudo -u stellar ./bin/horizon expingest init-genesis-state || true
+	fi
 
 	touch .quickstart-initialized
 	popd


### PR DESCRIPTION
This commit runs `horizon expingest init-genesis-state` to allow faster ingestion in standalone mode (see for the previous solution that waits for the first checkpoint before starting ingestion: https://github.com/stellar/docker-stellar-core-horizon/pull/164). Requires: https://github.com/stellar/go/pull/2910.