### PR TITLE
Switch to ubuntu 16.04 base and use apt packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM stellar/base:latest
+FROM ubuntu:16.04
 
 MAINTAINER Bartek Nowotarski <bartek@stellar.org>
 
-ENV STELLAR_CORE_VERSION 14.0.0-1310-9dd23416
-ENV HORIZON_VERSION 1.8.2
+ENV STELLAR_CORE_VERSION 14.0.0-37
+ENV HORIZON_VERSION 1.8.2-85
 
 EXPOSE 5432
 EXPOSE 8000
@@ -22,10 +22,6 @@ RUN /install
 RUN ["mkdir", "-p", "/opt/stellar"]
 RUN ["touch", "/opt/stellar/.docker-ephemeral"]
 
-RUN useradd --uid 10011001 --home-dir /home/stellar --no-log-init stellar \
-    && mkdir -p /home/stellar \
-    && chown -R stellar:stellar /home/stellar
-
 RUN ["ln", "-s", "/opt/stellar", "/stellar"]
 RUN ["ln", "-s", "/opt/stellar/core/etc/stellar-core.cfg", "/stellar-core.cfg"]
 RUN ["ln", "-s", "/opt/stellar/horizon/etc/horizon.env", "/horizon.env"]
@@ -38,4 +34,4 @@ ADD standalone /opt/stellar-default/standalone
 ADD start /
 RUN ["chmod", "+x", "start"]
 
-ENTRYPOINT ["/init", "--", "/start" ]
+ENTRYPOINT ["/start"]

--- a/Dockerfile.testing
+++ b/Dockerfile.testing
@@ -1,9 +1,9 @@
-FROM stellar/base:latest
+FROM ubuntu:16.04
 
 MAINTAINER Bartek Nowotarski <bartek@stellar.org>
 
-ENV STELLAR_CORE_VERSION 14.0.0-1310-9dd23416
-ENV HORIZON_VERSION 1.8.2
+ENV STELLAR_CORE_VERSION 14.0.0-37
+ENV HORIZON_VERSION 1.8.2-85
 
 EXPOSE 5432
 EXPOSE 8000
@@ -22,10 +22,6 @@ RUN /install
 RUN ["mkdir", "-p", "/opt/stellar"]
 RUN ["touch", "/opt/stellar/.docker-ephemeral"]
 
-RUN useradd --uid 10011001 --home-dir /home/stellar --no-log-init stellar \
-    && mkdir -p /home/stellar \
-    && chown -R stellar:stellar /home/stellar
-
 RUN ["ln", "-s", "/opt/stellar", "/stellar"]
 RUN ["ln", "-s", "/opt/stellar/core/etc/stellar-core.cfg", "/stellar-core.cfg"]
 RUN ["ln", "-s", "/opt/stellar/horizon/etc/horizon.env", "/horizon.env"]
@@ -38,4 +34,4 @@ ADD standalone /opt/stellar-default/standalone
 ADD start /
 RUN ["chmod", "+x", "start"]
 
-ENTRYPOINT ["/init", "--", "/start" ]
+ENTRYPOINT ["/start"]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This image provides a default, non-validating, ephemeral configuration that shou
 
 The image uses the following software:
 
-- Postgresql 9.6 is used for storing both stellar-core and horizon data
+- Postgresql 9.5 is used for storing both stellar-core and horizon data
 - [stellar-core](https://github.com/stellar/stellar-core)
 - [horizon](https://github.com/stellar/go/tree/master/services/horizon)
 - Supervisord is used from managing the processes of the services above

--- a/common/core/bin/start
+++ b/common/core/bin/start
@@ -7,4 +7,4 @@ done
 
 echo "starting core..."
 set -e
-exec /usr/local/bin/stellar-core --conf "/opt/stellar/core/etc/stellar-core.cfg" run
+exec /usr/bin/stellar-core --conf "/opt/stellar/core/etc/stellar-core.cfg" run

--- a/common/horizon/bin/horizon
+++ b/common/horizon/bin/horizon
@@ -4,4 +4,4 @@
 # environment variables before executing the actual binary.
 
 source /opt/stellar/horizon/etc/horizon.env
-exec /usr/local/bin/horizon $@
+exec /usr/bin/stellar-horizon $@

--- a/common/supervisor/etc/supervisord.conf
+++ b/common/supervisor/etc/supervisord.conf
@@ -15,7 +15,7 @@ serverurl=unix:///var/run/supervisor.sock
 
 [program:postgresql]
 user=postgres
-command=/usr/lib/postgresql/9.6/bin/postgres -D "/opt/stellar/postgresql/data" -c config_file=/opt/stellar/postgresql/etc/postgresql.conf
+command=/usr/lib/postgresql/9.5/bin/postgres -D "/opt/stellar/postgresql/data" -c config_file=/opt/stellar/postgresql/etc/postgresql.conf
 stopsignal=INT
 autostart=true
 autorestart=true

--- a/dependencies
+++ b/dependencies
@@ -3,8 +3,11 @@ set -e
 
 # dependencies
 apt-get update
-apt-get install -y curl git libpq-dev libsqlite3-dev libsasl2-dev postgresql-client postgresql postgresql-contrib sudo vim zlib1g-dev supervisor \
-	jq netcat # Parsing stellar-core JSON for standalone network and checking core HTTP server
+apt-get install -y curl wget git apt-transport-https \
+                   libpq-dev libsqlite3-dev libsasl2-dev \
+                   postgresql-client postgresql postgresql-contrib \
+                   sudo vim zlib1g-dev supervisor psmisc \
+                   jq netcat # Parsing stellar-core JSON for standalone network and checking core HTTP server
 apt-get clean
 
 echo "\nDone installing dependencies...\n"

--- a/install
+++ b/install
@@ -1,16 +1,11 @@
 #! /usr/bin/env bash
 set -e
 
-# stellar-core
-wget -O stellar-core.deb https://s3.amazonaws.com/stellar.org/releases/stellar-core/stellar-core-${STELLAR_CORE_VERSION}_amd64.deb
-dpkg -i stellar-core.deb
-rm stellar-core.deb
-
-# horizon
-wget -O horizon.tar.gz https://github.com/stellar/go/releases/download/horizon-v${HORIZON_VERSION}/horizon-v${HORIZON_VERSION}-linux-amd64.tar.gz
-tar -zxvf horizon.tar.gz
-mv /horizon-v${HORIZON_VERSION}-linux-amd64/horizon /usr/local/bin
-chmod +x /usr/local/bin/horizon
-rm -rf horizon.tar.gz /horizon-v${HORIZON_VERSION}-linux-amd64
-
+export DEBIAN_FRONTEND=noninteractive
+wget -qO - https://apt.stellar.org/SDF.asc | apt-key add -
+echo "deb https://apt.stellar.org xenial stable" >/etc/apt/sources.list.d/SDF.list
+apt-get update
+apt-get install -y stellar-core=${STELLAR_CORE_VERSION}
+apt-get install -y stellar-horizon=${HORIZON_VERSION}
+apt-get clean
 echo "\nDone installing stellar-core and horizon...\n"

--- a/start
+++ b/start
@@ -7,7 +7,7 @@ export SUPHOME="$STELLAR_HOME/supervisor"
 export COREHOME="$STELLAR_HOME/core"
 export HZHOME="$STELLAR_HOME/horizon"
 
-export PGBIN="/usr/lib/postgresql/9.6/bin"
+export PGBIN="/usr/lib/postgresql/9.5/bin"
 export PGDATA="$PGHOME/data"
 export PGUSER="stellar"
 export PGPORT=5432
@@ -174,9 +174,9 @@ function copy_pgpass() {
 	$CP /opt/stellar/postgresql/.pgpass /root/
 	chmod 0600 /root/.pgpass
 
-	$CP /opt/stellar/postgresql/.pgpass /home/stellar
-	chmod 0600 /home/stellar/.pgpass
-	chown stellar:stellar /home/stellar/.pgpass
+	$CP /opt/stellar/postgresql/.pgpass /var/lib/stellar
+	chmod 0600 /var/lib/stellar/.pgpass
+	chown stellar:stellar /var/lib/stellar/.pgpass
 }
 
 function init_db() {


### PR DESCRIPTION
This change removes dependency on the stellar-base image.

I tested testnet and pubnet modes and they work fine. Standalone mode is broken but it's also broken in the master branch