### PR TITLE
Clear Postgres data folder before initdb

### DIFF
--- a/start
+++ b/start
@@ -186,6 +186,12 @@ function init_db() {
 	fi
 	pushd $PGHOME
 
+	if [ ! -z "$(ls -a "$PGDATA")" ]
+	then
+		echo "clearing postgres data folder"
+		rm -rf $PGDATA
+	fi
+
 	# workaround!!!! from: https://github.com/nimiq/docker-postgresql93/issues/2
 	mkdir /etc/ssl/private-copy; mv /etc/ssl/private/* /etc/ssl/private-copy/; rm -r /etc/ssl/private; mv /etc/ssl/private-copy /etc/ssl/private; chmod -R 0700 /etc/ssl/private; chown -R postgres /etc/ssl/private
 	# end workaround


### PR DESCRIPTION
## Description

We are getting some reports from users that the consensus container can get in a state where it refused to start, and goes in a loop displaying an error related to Postgres. After investigation, it was found that the Postgres DB gets in a corrupted state, where it's impossible to init it, as the data folder is not empty, but the init is not skipped, as the .quickstart-initialized file is absent.

It seems like this problem would happen at start-up, when the user sets up the DB for the first time, and for an unknown reason, it becomes corrupted. A quick fix for this is to simply remove the Postgres data folder, as instructed in the Docker logs. We need to automate clearing that folder.

## Possible fixes

* Check if such an error happens from outside the container, and clear the Postgres folder. We want to do a `docker exec ... rm -rf ...`, so that we are certain to have the right permissions. This fix is implemented here: https://github.com/PiCoreTeam/pi-node-internal/pull/22. With this option, we have the possibility to check if the user has already initialized the blockchain data. In this cae, we can hold off from removing the directory.
* Clear the Postgres folder from inside the container. This allows us to perform the operation at the same place where the DB is initialized, with the right permissions.

I believe that number 2 is a cleaner fix, however we might be removing blockchain data from the user's machines. Another way to look at it is that whenever a user ends in the state where the issue happens, we know no way to restore the DB. It fails to start, even when creating a fake `.quickstart-initialized` file.

The approach I'm proposing is to make the fix from this PR, and keep ours eyes peeled for reports about loss of data. Supposedly this would happen only at startup time, so we wouldn't hear about any data loss, but if we do, we could revert this and instead implement the other fix.

## Testing

This fix was tested in local. The good thing about it, is that it shouldn't depend on the OS, since it's done from inside the container. We can try to contact the people that have been affected by the issue to check if it fixes it for them.