### PR TITLE
Horizon 2.0.0-rc

### DIFF
--- a/start
+++ b/start
@@ -296,7 +296,7 @@ EOF
 	run_silent "init-horizon-db" sudo -u stellar ./bin/horizon db init
 	if [ "$NETWORK" == "standalone" ]; then
 		# init-genesis-state command has not been released yet so ignore error and remove `|| true` later.
-		run_silent "init-genesis-state" sudo -u stellar ./bin/horizon expingest init-genesis-state || true
+		run_silent "init-genesis-state" sudo -u stellar ./bin/horizon ingest init-genesis-state || true
 	fi
 
 	touch .quickstart-initialized


### PR DESCRIPTION
Horizon 2.0.0-rc will change `horizon expingest` command to `horizon ingest`. This is draft PR to remember to update the call to `horizon ingest init-genesis-state`.