### PR TITLE
point DigitalOcean to master branch

### DIFF
--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -3,7 +3,7 @@ spec:
   services:
   - dockerfile_path: Dockerfile
     git:
-      branch: acharb-quickdeploy
+      branch: master
       repo_clone_url: https://github.com/stellar/docker-stellar-core-horizon.git
     name: docker-stellar-core-horizon
     run_command: /start --standalone --randomize-network-passphrase

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The root account is derived from the network passphrase and if the network passp
 
 In order to get started quickly, you can deploy the docker image to a DigitalOcean server by clicking the button below. It will create a container in *ephemeral mode* on the *standalone network* (with a random network passphrase) that can be connected to. Note: you will need to create a DigitalOcean account if you don't have one.
 
-[![Deploy to DO](https://www.deploytodo.com/do-btn-blue.svg)](https://cloud.digitalocean.com/apps/new?repo=https://github.com/stellar/docker-stellar-core-horizon/tree/acharb-quickdeploy)
+[![Deploy to DO](https://www.deploytodo.com/do-btn-blue.svg)](https://cloud.digitalocean.com/apps/new?repo=https://github.com/stellar/docker-stellar-core-horizon/tree/master)
 
 *Disclaimer*: The DigitalOcean server is publicly accessible on the Internet. Do not put sensitive information on the network that you would not want someone else to know. Anyone with access to the network will be able to use the root account above.
 


### PR DESCRIPTION
DigitalOcean should be pointing at master branch and not the feature branch (had to leave as feature branch in previous [PR](https://github.com/stellar/docker-stellar-core-horizon/pull/276) until it was merged for testing because needs the .do/deploy.template.yaml file to work)