### PR TITLE
change var to ENABLE_HORIZON_CAPTIVE_CORE

### DIFF
--- a/start
+++ b/start
@@ -274,7 +274,7 @@ function init_stellar_core() {
 
   run_silent "finalize-core-config-pgpass" sed -ri "s/__PGPASS__/$PGPASS/g" etc/stellar-core.cfg
   local RUN_STANDALONE=false
-  if [ "$NETWORK" = "standalone" ] && [ "$HORIZON_ENABLE_CAPTIVE_CORE" = "false" ]; then
+  if [ "$NETWORK" = "standalone" ] && [ "$ENABLE_HORIZON_CAPTIVE_CORE" = "false" ]; then
     RUN_STANDALONE=true
   fi
   run_silent "finalize-core-config-run-standalone" sed -ri "s/__RUN_STANDALONE__/$RUN_STANDALONE/g" etc/stellar-core.cfg


### PR DESCRIPTION
**WHAT**
changes a variable reference to `ENABLE_HORIZON_CAPTIVE_CORE`

**WHY**
before it was `HORIZON_ENABLE_CAPTIVE_CORE`, which there isn't any reference to in this repo

I'm not entirely sure why the `ENABLE_HORIZON_CAPTIVE_CORE` is being checked in order to set `RUN_STANDALONE=true`. From [this comment](https://github.com/stellar/stellar-core/blob/b08d3f6750bebd0b8a722354832ee8ef4682c0da/docs/stellar-core_example.cfg#L320-L323) in Core I would think that if we're running in standalone then it should be true whether in captive core or not.