### PR TITLE
Install rsync in 'dependencies' instead of 'install'

### DIFF
--- a/dependencies
+++ b/dependencies
@@ -8,7 +8,7 @@ apt-get install -y curl wget git apt-transport-https \
                    libpq-dev libsqlite3-dev libsasl2-dev \
                    postgresql-client postgresql postgresql-contrib \
                    sudo vim zlib1g-dev supervisor psmisc \
-                   jq netcat # Parsing stellar-core JSON for standalone network and checking core HTTP server
+                   rsync jq netcat # Parsing stellar-core JSON for standalone network and checking core HTTP server
 apt-get clean
 
 echo "\nDone installing dependencies...\n"

--- a/install
+++ b/install
@@ -2,7 +2,7 @@
 set -e
 
 export DEBIAN_FRONTEND=noninteractive
-apt-get -y install gnupg1 rsync wget
+apt-get -y install gnupg1 wget
 wget -qO - https://apt.stellar.org/SDF.asc | apt-key add -
 echo "deb https://apt.stellar.org focal stable" >/etc/apt/sources.list.d/SDF.list
 echo "deb https://apt.stellar.org focal unstable" >/etc/apt/sources.list.d/SDF-unstable.list


### PR DESCRIPTION
### What
Install `rsync` in `dependencies` instead of `install`.

### Why
`rsync` is a general dependency of the image, because it is used by the `start` script. It is not a dependency specifically for installing `stellar-core` or `stellar-horizon`, like `gnupg1` and `wget` are. It should be installed with the other dependencies.

This wouldn't appear to matter much, but for folks hacking on the docker image who might comment out the `install` script it is very inconvenient that doing so breaks other parts of the image that have nothing to do with the install script. 