### PR TITLE
Use Go version 1.20.1 to build horizon docker image

### DIFF
--- a/Dockerfile.horizon
+++ b/Dockerfile.horizon
@@ -1,4 +1,4 @@
-FROM golang:1.20.1 AS builder
+FROM golang:1.20 AS builder
 
 ARG REF
 WORKDIR /go/src/github.com/stellar/go


### PR DESCRIPTION


Related https://github.com/stellar/go/pull/4770