### PR TITLE
Slightly reduce "unlimited" tx size

### DIFF
--- a/local/core/etc/config-settings/p21/unlimited.json
+++ b/local/core/etc/config-settings/p21/unlimited.json
@@ -44,7 +44,7 @@
     {
       "contract_bandwidth_v0": {
         "ledger_max_txs_size_bytes": 4294967295,
-        "tx_max_size_bytes": 4294967295,
+        "tx_max_size_bytes": 4294965295,
         "fee_tx_size1_kb": 500
       }
     },

--- a/local/core/etc/config-settings/p22/unlimited.json
+++ b/local/core/etc/config-settings/p22/unlimited.json
@@ -44,7 +44,7 @@
     {
       "contract_bandwidth_v0": {
         "ledger_max_txs_size_bytes": 4294967295,
-        "tx_max_size_bytes": 4294967295,
+        "tx_max_size_bytes": 4294965295,
         "fee_tx_size1_kb": 500
       }
     },

--- a/local/core/etc/config-settings/p23/unlimited.json
+++ b/local/core/etc/config-settings/p23/unlimited.json
@@ -45,7 +45,7 @@
       "contract_bandwidth_v0": {
         "fee_tx_size1_kb": "500",
         "ledger_max_txs_size_bytes": 4294967295,
-        "tx_max_size_bytes": 4294967295
+        "tx_max_size_bytes": 4294965295
       }
     },
     {


### PR DESCRIPTION
This change reduces `tx_max_size_bytes` by 2000 bytes in the "unlimited" network settings as a temporary workaround until stellar/stellar-core#4903 is resolved and shipped in a stable release.