### PR TITLE
Remove 'Free up disk space' step from GitHub workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -396,13 +396,6 @@ jobs:
       image: ${{ steps.image.outputs.name }}
     runs-on: ubuntu-latest
     steps:
-    - name: Free up disk space
-      run: |
-        sudo rm -rf /usr/share/dotnet
-        sudo rm -rf /usr/local/lib/android
-        sudo rm -rf /opt/ghc
-        sudo rm -rf /opt/hostedtoolcache/CodeQL
-        df -h
     - uses: actions/checkout@v3
       with:
         ref: ${{ inputs.sha }}


### PR DESCRIPTION
### What
Remove the 'Free up disk space' step from the build workflow. 

### Why
Now that the intermediary image files are much smaller we no longer need to free up disk space. The free up disk space can take up to 40 seconds or longer.