### PR TITLE
Use macos-15-intel instead of macos-13

### DIFF
--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -34,7 +34,7 @@ jobs:
           const os = ['ubuntu-latest'];
           if (process.env.ACTION_CHANGED === 'true') {
             os.push('ubuntu-24.04-arm');
-            os.push('macos-13');
+            os.push('macos-15-intel');
           }
           core.setOutput('os', JSON.stringify(os));
 


### PR DESCRIPTION
### What
  Update macOS runner version from macos-13 to macos-15-intel for intel macos tests.

  ### Why
  The macos-15-intel runner is now available and is I would guess going to have more availability than the older.