### PR TITLE
Fix action test on scheduled ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,8 +97,8 @@ jobs:
     name: 3 test action artifact
     uses: ./.github/workflows/action-test.yml
     with:
-      artifact: image-quickstart-latest-amd64.tar
-      tag: latest-amd64
+      artifact: image-quickstart-${{ fromJSON(needs.setup.outputs.tags)[0] }}-${{ fromJSON(needs.setup.outputs.archs)[0] }}.tar
+      tag: ${{ fromJSON(needs.setup.outputs.tags)[0] }}-${{ fromJSON(needs.setup.outputs.archs)[0] }}
 
   push:
     name: 4 push
@@ -121,4 +121,4 @@ jobs:
     name: 5 test action registry
     uses: ./.github/workflows/action-test.yml
     with:
-      tag: ${{ needs.setup.outputs.tag-prefix }}latest
+      tag: ${{ needs.setup.outputs.tag-prefix }}${{ fromJSON(needs.setup.outputs.tags)[0] }}


### PR DESCRIPTION
### What
  Update the CI workflow to use dynamic artifact and tag names by replacing hardcoded values with expressions that reference outputs from previous jobs, selecting the first tag and arch that was built, whatever it is, to test.

  ### Why
  The workflow today runs an action test for latest amd64 because the action test really just needs to test one image, not all the images that got built. During a scheduled build, only the nightly image is built, not the latest image, and so the tests fail because there is no artifact for the latest. Example of failing test:
  - https://github.com/stellar/quickstart/actions/runs/18361687915/job/52308364116