### PR TITLE
Add nightly-next image configuration

### DIFF
--- a/images.json
+++ b/images.json
@@ -40,7 +40,7 @@
     "tag": "future",
     "events": ["pull_request", "push"],
     "config": {
-      "protocol_version_default": 24
+      "protocol_version_default": 23
     },
     "deps": [
       { "name": "xdr", "repo": "stellar/rs-stellar-xdr", "ref": "v23.0.0" },


### PR DESCRIPTION
### What
  Add nightly-next image configuration with push and schedule events that is the same as nightly but builds core with the next protocol enabled.

  ### Why
  To have a version of quickstart built and tested for basic compatibility with other components.