### PR TITLE
Add fallback config settings for local network

### DIFF
--- a/start
+++ b/start
@@ -338,12 +338,12 @@ function copy_defaults() {
       local config_dir_base="$COREHOME/etc/config-settings"
       local config_dir="$config_dir_base/p$PROTOCOL_VERSION"
       if [ ! -d "$config_dir" ]; then
-        # Symlink the config-dir from the most recent protocol version.
-        # For example, if $PROTOCOL_VERSION is 25, and there is no config
-        # settings for p25, look for config settings for p24, p23, so on until
-        # the directory exists. Once the directory exists, create a symlink for
-        # p25 -> p23.
-        for ((v=PROTOCOL_VERSION-1; v>=0; v--)); do
+        # Symlink the config-dir from the most recent protocol version. For
+        # example, if $PROTOCOL_VERSION is 25, and there is no config settings
+        # for p25, look for config settings for p24, p23, so on until the
+        # directory exists. Protocol 20 is the first protocol that has
+        # settings. Once the directory exists, create a symlink for p25 -> p23.
+        for ((v=PROTOCOL_VERSION-1; v>=20; v--)); do
           local v_dir="p$v"
           local fallback_dir="$config_dir_base/$v_dir"
           if [ -d "$fallback_dir" ]; then


### PR DESCRIPTION
### What
  Add fallback config settings for the local network for protocol versions that do not have config settings.

  ### Why
  Enable local network to use most recent protocol config when current version lacks settings. This is particularly helpful when the current version is in development and settings for it have not been developed. As is the case with the nightly-next build.