### PR TITLE
Fix passing of sha through ci workflow

### DIFF
--- a/.github/workflows/internal-build.yml
+++ b/.github/workflows/internal-build.yml
@@ -39,7 +39,7 @@ on:
       cache_id:
         description: "A value insert into cache keys to namespace cache usage, or invalidate it by incrementing"
         type: "string"
-        default: 14
+        default: 15
 
 env:
   artifact_retention_days_for_image: 7


### PR DESCRIPTION
### What
  Fix passing of sha through ci workflow.

  ### Why
  The sha is now passed as a parameter. The internal build workflow though was still trying to read a 'ref' parameter that doesn't exist. This results in the checkout checking out the pr commit. This may have resulted in the merge commit instead of the head commit being used in pull request runs, but the impact would have been unimportant.