### PR TITLE
Remove unused cache_id input from build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,10 +32,6 @@ on:
         description: "Whether the image tests should run"
         type: "boolean"
         default: true
-      cache_id:
-        description: "A value insert into cache keys to namespace cache usage, or invalidate it by incrementing"
-        type: "string"
-        default: 6
 
 env:
   artifact_retention_days_for_image: 7


### PR DESCRIPTION
### What
  Remove the cache_id input parameter from the build workflow configuration.

  ### Why
  The cache_id parameter is not used in this workflow and was a copy-paste mistake.