### PR TITLE
Update testing image deps to v24

### DIFF
--- a/images.json
+++ b/images.json
@@ -24,14 +24,14 @@
     "tag": "testing",
     "events": ["pull_request", "push"],
     "config": {
-      "protocol_version_default": 23
+      "protocol_version_default": 24
     },
     "deps": [
-      { "name": "xdr", "repo": "stellar/rs-stellar-xdr", "ref": "v23.0.0" },
-      { "name": "core", "repo": "stellar/stellar-core", "ref": "v23.0.1", "options": { "configure_flags": "--disable-tests" } },
-      { "name": "rpc", "repo": "stellar/stellar-rpc", "ref": "v23.0.4" },
-      { "name": "horizon", "repo": "stellar/go", "ref": "horizon-v23.0.0" },
-      { "name": "friendbot", "repo": "stellar/go", "ref": "horizon-v23.0.0" },
+      { "name": "xdr", "repo": "stellar/rs-stellar-xdr", "ref": "v24.0.0" },
+      { "name": "core", "repo": "stellar/stellar-core", "ref": "v24.0.0", "options": { "configure_flags": "--disable-tests" } },
+      { "name": "rpc", "repo": "stellar/stellar-rpc", "ref": "v24.0.0" },
+      { "name": "horizon", "repo": "stellar/go", "ref": "horizon-v24.0.0" },
+      { "name": "friendbot", "repo": "stellar/go", "ref": "horizon-v24.0.0" },
       { "name": "lab", "repo": "stellar/laboratory", "ref": "main" }
     ],
     "tests": {


### PR DESCRIPTION
### What
  Update testing image dependencies to v24. Set protocol version default to 24.

  ### Why
  The v24 release includes the latest protocol version that will be rolling out to testnet. The default protocol version can be updated because all software supports it.