### PR TITLE
Remove the nightly-next image

### DIFF
--- a/images.json
+++ b/images.json
@@ -79,24 +79,5 @@
       "continue-on-error": true,
       "additional-tests": []
     }
-  },
-  {
-    "tag": "nightly-next",
-    "events": ["push", "schedule"],
-    "config": {
-      "protocol_version_default": 24
-    },
-    "deps": [
-      { "name": "xdr", "repo": "stellar/rs-stellar-xdr", "ref": "main" },
-      { "name": "core", "repo": "stellar/stellar-core", "ref": "master", "options": { "configure_flags": "--disable-tests --enable-next-protocol-version-unsafe-for-production" } },
-      { "name": "rpc", "repo": "stellar/stellar-rpc", "ref": "main" },
-      { "name": "horizon", "repo": "stellar/go", "ref": "master" },
-      { "name": "friendbot", "repo": "stellar/go", "ref": "master" },
-      { "name": "lab", "repo": "stellar/laboratory", "ref": "main" }
-    ],
-    "tests": {
-      "continue-on-error": true,
-      "additional-tests": []
-    }
   }
 ]


### PR DESCRIPTION
### What
Remove the nightly-next image.

### Why
It is very unlikely the image will ever successfully build. The nightly-next image builds and includes core with the next protocol version enabled. However, Horizon and RPC explicitly will not sync to networks with a newer protocol than they support. All new protocol development for those softwares occurs on non-main/master branches, but the image currently references the main/master branch. Meaning the current image is unlikely to ever be of use.

I think it is likely that if an image exists for the next protocol, it'll be created at each protocol, something like `nightly-p24` like what had briefly in https://github.com/stellar/quickstart/pull/799, that will be configured to build from all the appropriate in-progress branches.