### PR TITLE
Upgrade latest deps to v24

### DIFF
--- a/images.json
+++ b/images.json
@@ -6,11 +6,11 @@
       "protocol_version_default": 23
     },
     "deps": [
-      { "name": "xdr", "repo": "stellar/rs-stellar-xdr", "ref": "v23.0.0" },
-      { "name": "core", "repo": "stellar/stellar-core", "ref": "v23.0.1", "options": { "configure_flags": "--disable-tests" } },
-      { "name": "rpc", "repo": "stellar/stellar-rpc", "ref": "v23.0.4" },
-      { "name": "horizon", "repo": "stellar/go", "ref": "horizon-v23.0.0" },
-      { "name": "friendbot", "repo": "stellar/go", "ref": "horizon-v23.0.0" },
+      { "name": "xdr", "repo": "stellar/rs-stellar-xdr", "ref": "v24.0.0" },
+      { "name": "core", "repo": "stellar/stellar-core", "ref": "v24.0.0", "options": { "configure_flags": "--disable-tests" } },
+      { "name": "rpc", "repo": "stellar/stellar-rpc", "ref": "v24.0.0" },
+      { "name": "horizon", "repo": "stellar/go", "ref": "horizon-v24.0.0" },
+      { "name": "friendbot", "repo": "stellar/go", "ref": "horizon-v24.0.0" },
       { "name": "lab", "repo": "stellar/laboratory", "ref": "main" }
     ],
     "tests": {


### PR DESCRIPTION
### What
  Upgrade stellar-xdr from v23.0.0 to v24.0.0, stellar-core from v23.0.1 to v24.0.0, stellar-rpc from v23.0.4 to v24.0.0, and horizon/friendbot from horizon-v23.0.0 to horizon-v24.0.0.

  ### Why
  All the versions are stable and can go into the latest image to maintain compatibility with pubnet.