### PR TITLE
Read protocol version default from config instead of setting additional env vars

### DIFF
--- a/.github/workflows/internal-build.yml
+++ b/.github/workflows/internal-build.yml
@@ -289,7 +289,6 @@ jobs:
         -t quickstart:${{ matrix.image.tag }}-${{ matrix.arch }}
         --label org.opencontainers.image.revision="${{ inputs.sha }}"
         --build-arg REVISION="${{ inputs.sha }}"
-        --build-arg PROTOCOL_VERSION_DEFAULT="${{ matrix.image.config.protocol_version_default }}"
         ${{ steps.dep_args.outputs.args }}
         .
     - name: Save Quickstart Image

--- a/Dockerfile
+++ b/Dockerfile
@@ -213,9 +213,4 @@ ADD futurenet /opt/stellar-default/futurenet
 ADD start /
 RUN ["chmod", "+x", "start"]
 
-
-ARG PROTOCOL_VERSION_DEFAULT
-RUN test -n "$PROTOCOL_VERSION_DEFAULT" || (echo "Image build arg PROTOCOL_VERSION_DEFAULT required and not set" && false)
-ENV PROTOCOL_VERSION_DEFAULT=$PROTOCOL_VERSION_DEFAULT
-
 ENTRYPOINT ["/start"]

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ IMAGE_JSON=.image.json
 	< images.json .scripts/images-with-extras | jq '.[] | select(.tag == "$(TAG)")' > $@
 
 # Extract configuration from selected image
-PROTOCOL_VERSION_DEFAULT = $(shell < $(IMAGE_JSON) jq -r '.config.protocol_version_default')
 XDR_REPO =       $(shell < $(IMAGE_JSON) jq -r '.deps[] | select(.name == "xdr") | .repo')
 XDR_SHA =        $(shell < $(IMAGE_JSON) jq -r '.deps[] | select(.name == "xdr") | .sha')
 CORE_REPO =      $(shell < $(IMAGE_JSON) jq -r '.deps[] | select(.name == "core") | .repo')
@@ -36,7 +35,6 @@ console:
 build: $(IMAGE_JSON)
 	docker build -t stellar/quickstart:$(TAG) -f Dockerfile . \
 		--build-arg REVISION=$(REVISION) \
-		--build-arg PROTOCOL_VERSION_DEFAULT=$(PROTOCOL_VERSION_DEFAULT) \
 		--build-arg XDR_REPO=$(XDR_REPO) --build-arg XDR_REF=$(XDR_SHA) \
 		--build-arg CORE_REPO="$(CORE_REPO)" --build-arg CORE_REF="$(CORE_SHA)" --build-arg CORE_OPTIONS='$(CORE_OPTIONS)' \
 		--build-arg RPC_REPO="$(RPC_REPO)" --build-arg RPC_REF="$(RPC_SHA)" \

--- a/start
+++ b/start
@@ -24,6 +24,8 @@ export PGDATA="$PGHOME/data"
 export PGUSER="stellar"
 export PGPORT=5432
 
+export PROTOCOL_VERSION_DEFAULT="$(< /image.json jq -r '.config.protocol_version_default')"
+
 : "${PROTOCOL_VERSION:=$PROTOCOL_VERSION_DEFAULT}"
 : "${ENABLE:=core,horizon,rpc}"
 : "${ENABLE_LOGS:=false}"


### PR DESCRIPTION
### What
  Remove PROTOCOL_VERSION_DEFAULT build argument and read the protocol version default directly from the config file at container startup instead of baking it into additional env values during build.

  ### Why
  This eliminates the need to pass the protocol version as a build argument, simplifying the build process and relying on the config living in the file which it does.