### PR TITLE
Try GHA layer caching instead of full image caching

### DIFF
--- a/.github/workflows/internal-build.yml
+++ b/.github/workflows/internal-build.yml
@@ -142,10 +142,9 @@ jobs:
         -t quickstart:${{ matrix.image.tag }}-${{ matrix.arch }}
         --label org.opencontainers.image.revision="${{ inputs.sha }}"
         --build-arg REVISION="${{ inputs.sha }}"
+        --output type=docker,dest=/tmp/image
         ${{ steps.dep_args.outputs.args }}
         .
-    - name: Save Quickstart Image
-      run: docker save quickstart -o /tmp/image
     - name: Upload Quickstart Image to Artifacts
       uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
### What
  Replace full Docker image caching via artifacts with GitHub Actions layer caching. Remove the load, prepare, and build-dep jobs that handled image restoration and intermediate builds. Update build job to construct images directly using build args instead of pre-built image references, and configure GHA layer cache with zstd compression.

  ### Why
  To see how it compared to build everything on a single 4 core instance vs prebuild each image on its own 4 core instance.