### PR TITLE
Add Slack notification for CI failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
 
   notify:
     name: 7 slack notify on failure
-    if: always() # && github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'schedule') && contains(needs.*.result, 'failure')
+    if: always() && github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'schedule') && contains(needs.*.result, 'failure')
     needs: [setup, build, test, push]
     runs-on: ubuntu-latest
     continue-on-error: true


### PR DESCRIPTION
### What
  Add a notification job to the CI workflow that sends Slack messages when builds fail on the main branch. Implement caching to prevent duplicate notifications for the same image configuration.

  ### Why
  Teams need immediate visibility into CI failures on the main branch to respond quickly to broken builds without being spammed by repeated notifications.