### PR TITLE
Update friendbot source to be new repository

### DIFF
--- a/images.json
+++ b/images.json
@@ -53,7 +53,7 @@
       { "name": "core", "repo": "stellar/stellar-core", "ref": "v23.0.1", "options": { "configure_flags": "--disable-tests" } },
       { "name": "rpc", "repo": "stellar/stellar-rpc", "ref": "v23.0.4" },
       { "name": "horizon", "repo": "stellar/go", "ref": "horizon-v23.0.0" },
-      { "name": "friendbot", "repo": "stellar/friendbot", "ref": "horizon-v23.0.0" },
+      { "name": "friendbot", "repo": "stellar/go", "ref": "horizon-v23.0.0" },
       { "name": "lab", "repo": "stellar/laboratory", "ref": "main" }
     ],
     "tests": {


### PR DESCRIPTION
### What
  Update friendbot image configuration to reference the stellar/friendbot repository instead of stellar/go for the nightly images.

  ### Why
  Friendbot has been extracted into its own repository, requiring updated image sources for nightly builds because they build off the latest code.

The latest, testing, and futurenet builds will be updated separately.

For stellar/friendbot#4