### PR TITLE
Fix ci for prs from forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,7 @@ jobs:
       tag: ${{ fromJSON(needs.setup.outputs.tags)[0] }}-${{ fromJSON(needs.setup.outputs.archs)[0] }}
 
   push:
+    if: ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
     name: 5 push
     needs: [setup, build]
     uses: ./.github/workflows/internal-push.yml
@@ -133,6 +134,7 @@ jobs:
       registry_password: ${{ secrets.DOCKERHUB_TOKEN || github.token }}
 
   action-using-registry:
+    if: ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
     needs: [setup, push]
     name: 6 test action registry
     uses: ./.github/workflows/internal-action-test.yml


### PR DESCRIPTION
### What
  Add conditional execution logic to the push and action-using-registry jobs in the CI workflow. Those jobs now only run on pushes or schedules to the main branch, or on pull requests from the same repository.

  ### Why
  This prevents the push and action jobs from executing on external pull requests where they would fail due to missing registry credentials, while still allowing them to run build and tests.

This fixes the failures seen in:
- https://github.com/stellar/quickstart/pull/820
- https://github.com/stellar/quickstart/pull/821