### PR TITLE
Limit cancel-in-progress for CI to pull requests only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ on:
 # main, where a build for every commit will run.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_protected == true && github.sha || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
 


### PR DESCRIPTION
### What
  Make cancel-in-progress conditional on pull request events in the CI workflow concurrency configuration.

  ### Why
  This ensures every commit on protected branches like main runs to completion while still canceling redundant builds on pull requests. On the main branch builds run for two reasons: pushes, and scheduled runs. Pushes build most images, and scheduled runs build only nightly images. @sisuresh noticed that the main scheduled runs ([eg](https://github.com/stellar/quickstart/actions/runs/19745699438)) are causing the push runs to be canceled because they run for the same commit. It's a good thing that the workflow causes the push and scheduled builds on the main branch to be serialised so only one runs at a time. But a scheduled build shouldn't cancel a push build.