### PR TITLE
Increase test timeout multiplier to 4

### DIFF
--- a/.github/workflows/internal-test.yml
+++ b/.github/workflows/internal-test.yml
@@ -27,6 +27,7 @@ on:
 
 env:
   artifact_retention_days_for_logs: 60
+  timeout_multiplier: 4
 
 jobs:
 
@@ -115,7 +116,7 @@ jobs:
       run: sleep 10
     - name: Calculate timeout
       id: timeout
-      run: echo "minutes=$((${{ github.run_attempt }} * 2))" >> $GITHUB_OUTPUT
+      run: echo "minutes=$((${{ github.run_attempt }} * ${{ env.timeout_multiplier }}))" >> $GITHUB_OUTPUT
     - name: Run core test
       if: ${{ contains(matrix.enable, 'core') }}
       timeout-minutes: ${{ fromJSON(steps.timeout.outputs.minutes) }}


### PR DESCRIPTION
### What
  Add a timeout_multiplier environment variable set to 4 minutes and use it in the timeout calculation instead of the hardcoded value of 2 minutes.

  ### Why
  Tests were timing out with the previous 2 minute multiplier, but passing when rerun one time meaning they are passing inside of 4 minutes.