### PR TITLE
Fix pull of correct base image

### DIFF
--- a/.github/workflows/internal-build.yml
+++ b/.github/workflows/internal-build.yml
@@ -299,7 +299,7 @@ jobs:
           docker load -i $image
         done
     - name: Pull Base Image
-      run: docker pull --platform linux/${{ matrix.arch }} ubuntu:22.04
+      run: docker pull --platform linux/${{ matrix.arch }} ubuntu:24.04
     - name: Build Args for Deps
       id: dep_args
       run: |


### PR DESCRIPTION
### What
Change the image that is pulled during the build of the QuickStart image to Ubuntu 24.04. 

### Why
In https://github.com/stellar/quickstart/commit/0691ac46beea85fd0893582829694ac401858462 I upgraded the base images to 24.04 but missed updating the pull in the workflow that ensures that we always use the most recent 24.04 image. 