### PR TITLE
Fix ledger-meta-store exit 127 in local mode when galexie not running

### DIFF
--- a/local/supervisor/etc/supervisord.conf.d/ledger-meta-store.conf
+++ b/local/supervisor/etc/supervisord.conf.d/ledger-meta-store.conf
@@ -2,7 +2,7 @@
 user=stellar
 directory=/opt/stellar/ledger-meta-store/data
 command=/usr/bin/python3 -m http.server 1571
-autostart=true
+autostart=false
 autorestart=true
 startretries=100
 priority=10

--- a/start
+++ b/start
@@ -788,6 +788,7 @@ function start_optional_services() {
   fi
 
   if [ "$ENABLE_GALEXIE" == "true" ]; then
+    supervisorctl start ledger-meta-store
     supervisorctl start galexie
   fi
 }


### PR DESCRIPTION
### What:
Disable autostart for ledger-meta-store supervisor service and start it explicitly only when galexie is enabled.

### Why:
The ledger-meta-store service was failing with exit status 127 in --local mode when galexie was not enabled. The service auto-started but its working directory (/opt/stellar/ledger-meta-store/data) only exists when galexie is enabled, causing repeated supervisor warnings. The service is only needed when galexie is running and so it should only run then.

Close #894 