### PR TITLE
Fix container restart issues in local mode

### DIFF
--- a/start
+++ b/start
@@ -543,6 +543,10 @@ EOF
 }
 
 function init_friendbot() {
+  if [ -f $FBHOME/.quickstart-initialized ]; then
+    echo "friendbot: already initialized"
+    return 0
+  fi
   pushd $FBHOME
 
   perl -pi -e "s/__NETWORK__/$NETWORK_PASSPHRASE/g" etc/friendbot.cfg
@@ -555,6 +559,7 @@ function init_friendbot() {
     echo 'horizon_url = "http://localhost:8001"' >> etc/friendbot.cfg
   fi
 
+  touch .quickstart-initialized
   popd
 }
 


### PR DESCRIPTION
### What
Fix several issues that prevent the quickstart container from restarting cleanly in `--local` mode with persistent data, either data saved in a volume or a stopped and restarted container.

**Changes:**
1. **Skip Soroban config upgrades if already applied** - Add sentinel file check (`.upgrade-config-initialized`) to `upgrade_local()` to skip config upgrades on restart
2. **Skip friendbot init if already initialized** - Add sentinel file check (`.quickstart-initialized`) to `init_friendbot()` to prevent re-initialization on restart

### Why
When the container restarts with `--local` and a persistent ledger:
- Soroban config upgrades fail because the root account has sourced prior transactions and the hardcoded account sequence is out-of-date
- Friendbot init was running on every start and isn't idempotent, overwriting configuration on each restart corrupting the config file

These failures would trigger service shutdown, making the container non-restartable without removal.

Close #896