### PR TITLE
Update actions/setup-go to v6

### DIFF
--- a/.github/workflows/internal-test.yml
+++ b/.github/workflows/internal-test.yml
@@ -109,7 +109,7 @@ jobs:
         --enable ${{ matrix.enable }}
         ${{ matrix.options }}
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v6
       with:
         go-version: ^1
     - name: Sleep until supervisor is up


### PR DESCRIPTION
Update actions/setup-go to v6.

Versions of actions/setup-go prior to v4 no longer work due to changes in the Go download URLs (see https://github.com/actions/setup-go/issues/688). While updating repos affected by that, figured may as well update all repos using any version earlier than the latest.