### PR TITLE
Update testing image to stellar-core v27.0.0 release candidate

### DIFF
--- a/images.json
+++ b/images.json
@@ -6,7 +6,7 @@
       "push"
     ],
     "config": {
-      "protocol_version_default": 25
+      "protocol_version_default": 26
     },
     "deps": [
       {
@@ -72,7 +72,7 @@
       "push"
     ],
     "config": {
-      "protocol_version_default": 25
+      "protocol_version_default": 26
     },
     "deps": [
       {

--- a/images.json
+++ b/images.json
@@ -84,7 +84,6 @@
         "name": "core",
         "repo": "stellar/stellar-core",
         "ref": "7696c069d720fb450caeae940769b0a78a157363",
-        "comment": "v27.0.0 release candidate",
         "options": {
           "configure_flags": "--disable-tests"
         }

--- a/images.json
+++ b/images.json
@@ -83,7 +83,7 @@
       {
         "name": "core",
         "repo": "stellar/stellar-core",
-        "ref": "v26.1.0",
+        "ref": "7696c069d720fb450caeae940769b0a78a157363",
         "options": {
           "configure_flags": "--disable-tests"
         }

--- a/images.json
+++ b/images.json
@@ -84,6 +84,7 @@
         "name": "core",
         "repo": "stellar/stellar-core",
         "ref": "7696c069d720fb450caeae940769b0a78a157363",
+        "comment": "v27.0.0 release candidate",
         "options": {
           "configure_flags": "--disable-tests"
         }


### PR DESCRIPTION
Updates the `testing` image's stellar-core ref to `7696c069d720fb450caeae940769b0a78a157363`, which is the v27.0.0 release candidate.

The auto-update workflow picks up release candidates from the public stellar-core repo. We changed out release process to not use the public repo for RCs, so they no longer get picked up. I took note of this as something to address as part of the v27 releases retro.