### PR TITLE
Raise CI test step timeout multiplier to 8

### DIFF
--- a/.github/workflows/internal-test.yml
+++ b/.github/workflows/internal-test.yml
@@ -27,7 +27,7 @@ on:
 
 env:
   artifact_retention_days_for_logs: 60
-  timeout_multiplier: 4
+  timeout_multiplier: 6
 
 jobs:
 

--- a/.github/workflows/internal-test.yml
+++ b/.github/workflows/internal-test.yml
@@ -27,7 +27,7 @@ on:
 
 env:
   artifact_retention_days_for_logs: 60
-  timeout_multiplier: 6
+  timeout_multiplier: 8
 
 jobs:
 


### PR DESCRIPTION
### What
Raise the test workflow's timeout multiplier so each test step is allotted eight minutes on a first attempt instead of four.

### Why
The CI run periodically fails on the testing image's testnet core,rpc,horizon test: the "Run horizon core up test" step waits for Horizon's captive-core to catch up from the testnet history archive, and that catch-up has crept up to right around the four-minute step timeout — it was measured at 3m56s (passing with seconds to spare) on May 22 and exceeded four minutes on June 15 — so the step gets killed mid-sync even though the services are healthy and progressing. The test programs poll indefinitely, so this step-level timeout is the only bound. Eight minutes is chosen deliberately rather than guessed: it matches the budget that successful retries already use (a re-run doubles the timeout via run_attempt and reliably passes), and it is roughly twice the measured step duration, leaving headroom as the testnet history archive continues to grow. The increase costs nothing on healthy runs because each step exits the moment its service is ready; it only lets slow runs finish instead of being cut off.