### PR TITLE
SPIKE: Protocol 28 (CAP-0084) — nightly-next on p28 forks

### DIFF
--- a/images.json
+++ b/images.json
@@ -260,36 +260,37 @@
   {
     "tag": "nightly-next",
     "events": [
+      "pull_request",
       "push",
       "schedule"
     ],
     "config": {
-      "protocol_version_default": 27,
+      "protocol_version_default": 28,
       "horizon_skip_protocol_version_check": true
     },
     "deps": [
       {
         "name": "xdr",
-        "repo": "stellar/rs-stellar-xdr",
-        "ref": "main"
+        "repo": "sisuresh/rs-stellar-xdr",
+        "ref": "bd30d420ce6f63ccd9360e371830384cb84d1c04"
       },
       {
         "name": "core",
-        "repo": "stellar/stellar-core",
-        "ref": "master",
+        "repo": "sisuresh/stellar-core",
+        "ref": "fc0a370d044b2ab8f69b966b069c830f1ba55f4a",
         "options": {
           "configure_flags": "--disable-tests --enable-next-protocol-version-unsafe-for-production"
         }
       },
       {
         "name": "rpc",
-        "repo": "stellar/stellar-rpc",
-        "ref": "protocol-next"
+        "repo": "sisuresh/stellar-rpc",
+        "ref": "16dbf8aa5417468366a88407d14a79212b17a75d"
       },
       {
         "name": "horizon",
-        "repo": "stellar/stellar-horizon",
-        "ref": "protocol-next",
+        "repo": "sisuresh/stellar-horizon",
+        "ref": "7b8b493befe590cefc1739951049c8b19d005e27",
         "options": {
           "pkg": "github.com/stellar/stellar-horizon"
         }
@@ -304,8 +305,8 @@
       },
       {
         "name": "lab",
-        "repo": "stellar/laboratory",
-        "ref": "main"
+        "repo": "sisuresh/laboratory",
+        "ref": "208e83667aafa875ac63d136ed594d8c0c2cf72a"
       },
       {
         "name": "galexie",


### PR DESCRIPTION
SPIKE validating the Protocol 28 (CAP-0084) stack end-to-end via quickstart's `nightly-next` build.

## Changes
- `nightly-next` in `images.json`: `protocol_version_default` 27 → 28.
- Repoint xdr/core/rpc/horizon/lab deps to `sisuresh/*` forks pinned at their `p28-cap-0084` HEAD SHAs (quickstart builds each from source, so no Jenkins `-vnext` artifact is needed). friendbot/galexie untouched.
- Add `pull_request` to `nightly-next.events` so this SPIKE PR actually builds+tests the stack (SPIKE-only — revert before any non-draft merge).

## Deferred
- Bundled `stellar-xdr` CLI is built with hardcoded `--features cli`; may lack `cap_28` decode. Out of SPIKE scope, doesn't affect the validation path.
- galexie left at `stellar/stellar-galexie@protocol-next` (no p28 fork); SKIP if it breaks the build.

## Upstream
Consumes the P28 stack:
- xdr (defs): https://github.com/stellar/stellar-xdr/pull/305
- rs-stellar-xdr: https://github.com/stellar/rs-stellar-xdr/pull/548
- rs-soroban-env: https://github.com/stellar/rs-soroban-env/pull/1695
- rs-soroban-sdk: https://github.com/stellar/rs-soroban-sdk/pull/1921
- stellar-core: https://github.com/sisuresh/stellar-core/pull/17
- go (monorepo): https://github.com/sisuresh/go/pull/1
- stellar-horizon: https://github.com/stellar/stellar-horizon/pull/199
- stellar-rpc: https://github.com/stellar/stellar-rpc/pull/822
- js-stellar-base: https://github.com/sisuresh/js-stellar-base/pull/2
- js-stellar-sdk: https://github.com/sisuresh/js-stellar-sdk/pull/2
- js-stellar-xdr-json: https://github.com/sisuresh/js-stellar-xdr-json/pull/2
- laboratory: https://github.com/sisuresh/laboratory/pull/2
