### PR TITLE
SPIKE: Protocol 28 (CAP-0084)

### DIFF
--- a/images.json
+++ b/images.json
@@ -272,12 +272,12 @@
       {
         "name": "xdr",
         "repo": "sisuresh/rs-stellar-xdr",
-        "ref": "7b46a60d914c1e5befd6a2d2c50d2fdf7e5eb1f0"
+        "ref": "8f826caa99f3b4c55e4d958eb5b6a9a1dbbf9873"
       },
       {
         "name": "core",
         "repo": "sisuresh/stellar-core",
-        "ref": "e32fa4234e767b1dea40a2b06f1250b23999bf73",
+        "ref": "ec7022dfa691a51c6c7d5d4e7ae1321709559fce",
         "options": {
           "configure_flags": "--disable-tests --enable-next-protocol-version-unsafe-for-production"
         }
@@ -285,12 +285,12 @@
       {
         "name": "rpc",
         "repo": "sisuresh/stellar-rpc",
-        "ref": "cd4e29cd0aa1d81feb2b74f5a116da2eff873b3c"
+        "ref": "a240dc47c28a2c42353def635902eb14e9e69faa"
       },
       {
         "name": "horizon",
         "repo": "sisuresh/stellar-horizon",
-        "ref": "51fd10ebcf4021ffc205457c5d644391ea37592d",
+        "ref": "7ebefc4c0254bce5180da02f379bd52f9fe54106",
         "options": {
           "pkg": "github.com/stellar/stellar-horizon"
         }

--- a/images.json
+++ b/images.json
@@ -277,7 +277,7 @@
       {
         "name": "core",
         "repo": "sisuresh/stellar-core",
-        "ref": "ec7022dfa691a51c6c7d5d4e7ae1321709559fce",
+        "ref": "b2b06a8e6e8f6de0edecdb1666a79ba0d8eb4673",
         "options": {
           "configure_flags": "--disable-tests --enable-next-protocol-version-unsafe-for-production"
         }

--- a/images.json
+++ b/images.json
@@ -272,12 +272,12 @@
       {
         "name": "xdr",
         "repo": "sisuresh/rs-stellar-xdr",
-        "ref": "bd30d420ce6f63ccd9360e371830384cb84d1c04"
+        "ref": "7b46a60d914c1e5befd6a2d2c50d2fdf7e5eb1f0"
       },
       {
         "name": "core",
         "repo": "sisuresh/stellar-core",
-        "ref": "fc0a370d044b2ab8f69b966b069c830f1ba55f4a",
+        "ref": "e32fa4234e767b1dea40a2b06f1250b23999bf73",
         "options": {
           "configure_flags": "--disable-tests --enable-next-protocol-version-unsafe-for-production"
         }
@@ -285,12 +285,12 @@
       {
         "name": "rpc",
         "repo": "sisuresh/stellar-rpc",
-        "ref": "16dbf8aa5417468366a88407d14a79212b17a75d"
+        "ref": "cd4e29cd0aa1d81feb2b74f5a116da2eff873b3c"
       },
       {
         "name": "horizon",
         "repo": "sisuresh/stellar-horizon",
-        "ref": "7b8b493befe590cefc1739951049c8b19d005e27",
+        "ref": "51fd10ebcf4021ffc205457c5d644391ea37592d",
         "options": {
           "pkg": "github.com/stellar/stellar-horizon"
         }
@@ -306,7 +306,7 @@
       {
         "name": "lab",
         "repo": "sisuresh/laboratory",
-        "ref": "208e83667aafa875ac63d136ed594d8c0c2cf72a"
+        "ref": "634add38dbaad2eb2bbdf23eae6dd0a69f153864"
       },
       {
         "name": "galexie",

--- a/images.json
+++ b/images.json
@@ -260,36 +260,37 @@
   {
     "tag": "nightly-next",
     "events": [
+      "pull_request",
       "push",
       "schedule"
     ],
     "config": {
-      "protocol_version_default": 27,
+      "protocol_version_default": 28,
       "horizon_skip_protocol_version_check": true
     },
     "deps": [
       {
         "name": "xdr",
-        "repo": "stellar/rs-stellar-xdr",
-        "ref": "main"
+        "repo": "sisuresh/rs-stellar-xdr",
+        "ref": "bd30d420ce6f63ccd9360e371830384cb84d1c04"
       },
       {
         "name": "core",
-        "repo": "stellar/stellar-core",
-        "ref": "master",
+        "repo": "sisuresh/stellar-core",
+        "ref": "fc0a370d044b2ab8f69b966b069c830f1ba55f4a",
         "options": {
           "configure_flags": "--disable-tests --enable-next-protocol-version-unsafe-for-production"
         }
       },
       {
         "name": "rpc",
-        "repo": "stellar/stellar-rpc",
-        "ref": "protocol-next"
+        "repo": "sisuresh/stellar-rpc",
+        "ref": "16dbf8aa5417468366a88407d14a79212b17a75d"
       },
       {
         "name": "horizon",
-        "repo": "stellar/stellar-horizon",
-        "ref": "protocol-next",
+        "repo": "sisuresh/stellar-horizon",
+        "ref": "7b8b493befe590cefc1739951049c8b19d005e27",
         "options": {
           "pkg": "github.com/stellar/stellar-horizon"
         }
@@ -304,8 +305,8 @@
       },
       {
         "name": "lab",
-        "repo": "stellar/laboratory",
-        "ref": "main"
+        "repo": "sisuresh/laboratory",
+        "ref": "208e83667aafa875ac63d136ed594d8c0c2cf72a"
       },
       {
         "name": "galexie",


### PR DESCRIPTION
SPIKE bumping the Quickstart `nightly-next` variant to **Protocol 28 / CAP-0084 (Muxed Contract Addresses)**. `nightly-next` builds every dependency from source, so it pins each service to its CAP-0084 fork branch HEAD (re-pinned to current heads; earlier pins had gone stale). Draft until the upstream chain merges; the `pull_request` event is added SPIKE-only and must be reverted before merge.

## Changes
- Re-pin `nightly-next` deps to current fork heads:
  - rs-stellar-xdr → stellar/rs-stellar-xdr#549 @ `7b46a60`
  - stellar-core → sisuresh/stellar-core#18 (mirror of stellar/stellar-core#5332) @ `e32fa42`
  - stellar-rpc → stellar/stellar-rpc#827 @ `cd4e29c`
  - stellar-horizon → stellar/stellar-horizon#200 @ `51fd10e`
  - laboratory → stellar/laboratory#2131 @ `634add3`
- friendbot/galexie unchanged.

## Deferred
- Revert the SPIKE-only `pull_request` event and flip fork SHAs to merged upstream commits before any non-draft merge.

Top of the dep chain: stellar/stellar-xdr#306.
