### PR TITLE
Set default protocol version to 27

### DIFF
--- a/images.json
+++ b/images.json
@@ -6,7 +6,7 @@
       "push"
     ],
     "config": {
-      "protocol_version_default": 25
+      "protocol_version_default": 27
     },
     "deps": [
       {


### PR DESCRIPTION
Updates `protocol_version_default` in `images.json` from 25 to 27, making protocol 27 the default protocol version for the quickstart image.