### PR TITLE
Set testing image default protocol version to 27

### DIFF
--- a/images.json
+++ b/images.json
@@ -72,7 +72,7 @@
       "push"
     ],
     "config": {
-      "protocol_version_default": 25
+      "protocol_version_default": 27
     },
     "deps": [
       {


### PR DESCRIPTION
### What

Bump the `testing` image's default network protocol version from 25 to 27 so it matches the stellar-core v27.1.0 that the image already ships, bringing it in line with the `latest` tag.

### Why

Looks like this got missed updating. The default protocol version should track testnet.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L87cfKMZ3ZG57n84Ww4Uwa)_