### PR TITLE
Refresh pubnet config quorums

### DIFF
--- a/pubnet/core/etc/stellar-core.cfg
+++ b/pubnet/core/etc/stellar-core.cfg
@@ -16,15 +16,15 @@ HOME_DOMAIN = "publicnode.org"
 QUALITY = "HIGH"
 
 [[HOME_DOMAINS]]
-HOME_DOMAIN = "satoshipay.io"
-QUALITY = "HIGH"
-
-[[HOME_DOMAINS]]
 HOME_DOMAIN = "stellar.blockdaemon.com"
 QUALITY = "HIGH"
 
 [[HOME_DOMAINS]]
 HOME_DOMAIN = "stellar.creit.tech"
+QUALITY = "HIGH"
+
+[[HOME_DOMAINS]]
+HOME_DOMAIN = "stellar.withobsrvr.com"
 QUALITY = "HIGH"
 
 [[HOME_DOMAINS]]
@@ -78,27 +78,6 @@ HISTORY = "curl -sf https://lyra-history.publicnode.org/{0} -o {1}"
 HOME_DOMAIN = "publicnode.org"
 
 [[VALIDATORS]]
-NAME = "SatoshiPay Frankfurt"
-PUBLIC_KEY = "GC5SXLNAM3C4NMGK2PXK4R34B5GNZ47FYQ24ZIBFDFOCU6D4KBN4POAE"
-ADDRESS = "stellar-de-fra.satoshipay.io:11625"
-HISTORY = "curl -sf https://stellar-history-de-fra.satoshipay.io/{0} -o {1}"
-HOME_DOMAIN = "satoshipay.io"
-
-[[VALIDATORS]]
-NAME = "SatoshiPay Iowa"
-PUBLIC_KEY = "GAK6Z5UVGUVSEK6PEOCAYJISTT5EJBB34PN3NOLEQG2SUKXRVV2F6HZY"
-ADDRESS = "stellar-us-iowa.satoshipay.io:11625"
-HISTORY = "curl -sf https://stellar-history-us-iowa.satoshipay.io/{0} -o {1}"
-HOME_DOMAIN = "satoshipay.io"
-
-[[VALIDATORS]]
-NAME = "SatoshiPay Singapore"
-PUBLIC_KEY = "GBJQUIXUO4XSNPAUT6ODLZUJRV2NPXYASKUBY4G5MYP3M47PCVI55MNT"
-ADDRESS = "stellar-sg-sin.satoshipay.io:11625"
-HISTORY = "curl -sf https://stellar-history-sg-sin.satoshipay.io/{0} -o {1}"
-HOME_DOMAIN = "satoshipay.io"
-
-[[VALIDATORS]]
 NAME = "Blockdaemon Validator 1"
 PUBLIC_KEY = "GAAV2GCVFLNN522ORUYFV33E76VPC22E72S75AQ6MBR5V45Z5DWVPWEU"
 ADDRESS = "stellar-full-validator1.bdnodes.net:11625"
@@ -139,6 +118,27 @@ PUBLIC_KEY = "GBF7QOLFPTHUEDUPTT4ZTULDTA3QXDIO75JHKJN2IYD7YGQLYUTR75BT"
 ADDRESS = "gamma.validator.stellar.creit.tech:11625"
 HISTORY = "curl -sf https://gamma-history.validator.stellar.creit.tech/{0} -o {1}"
 HOME_DOMAIN = "stellar.creit.tech"
+
+[[VALIDATORS]]
+NAME = "OBSRVR Validator 1"
+PUBLIC_KEY = "GDRCZ4IPJR7V3HK4GR45CRTE72SDAOZUF2TDBQ5E5IGWC4KM5TSKU2LS"
+ADDRESS = "core-live-1.nodeswithobsrvr.co:11625"
+HISTORY = "curl -sf https://history-1.nodeswithobsrvr.co/obsrvr-core-1/{0} -o {1}"
+HOME_DOMAIN = "stellar.withobsrvr.com"
+
+[[VALIDATORS]]
+NAME = "OBSRVR Validator 2"
+PUBLIC_KEY = "GA2PU4UGMLSFUXGZATHPTDXXX7FOHBAQC57RSJCQUN72WFKTD6CEPQSF"
+ADDRESS = "core-live-2.nodeswithobsrvr.co:11625"
+HISTORY = "curl -sf https://history-2.nodeswithobsrvr.co/obsrvr-core-2/{0} -o {1}"
+HOME_DOMAIN = "stellar.withobsrvr.com"
+
+[[VALIDATORS]]
+NAME = "OBSRVR Validator 3"
+PUBLIC_KEY = "GACM6GIRMLXBBZIYJXBDTAEYZ2GJP3JJP5G5K4WDPBS6QFHPJNK6S2FB"
+ADDRESS = "core-live-3.nodeswithobsrvr.co:11625"
+HISTORY = "curl -sf https://history-3.nodeswithobsrvr.co/obsrvr-core-3/{0} -o {1}"
+HOME_DOMAIN = "stellar.withobsrvr.com"
 
 [[VALIDATORS]]
 NAME = "FT SCV 1"

--- a/pubnet/horizon/etc/stellar-captive-core.cfg
+++ b/pubnet/horizon/etc/stellar-captive-core.cfg
@@ -18,15 +18,15 @@ HOME_DOMAIN = "publicnode.org"
 QUALITY = "HIGH"
 
 [[HOME_DOMAINS]]
-HOME_DOMAIN = "satoshipay.io"
-QUALITY = "HIGH"
-
-[[HOME_DOMAINS]]
 HOME_DOMAIN = "stellar.blockdaemon.com"
 QUALITY = "HIGH"
 
 [[HOME_DOMAINS]]
 HOME_DOMAIN = "stellar.creit.tech"
+QUALITY = "HIGH"
+
+[[HOME_DOMAINS]]
+HOME_DOMAIN = "stellar.withobsrvr.com"
 QUALITY = "HIGH"
 
 [[HOME_DOMAINS]]
@@ -80,27 +80,6 @@ HISTORY = "curl -sf https://lyra-history.publicnode.org/{0} -o {1}"
 HOME_DOMAIN = "publicnode.org"
 
 [[VALIDATORS]]
-NAME = "SatoshiPay Frankfurt"
-PUBLIC_KEY = "GC5SXLNAM3C4NMGK2PXK4R34B5GNZ47FYQ24ZIBFDFOCU6D4KBN4POAE"
-ADDRESS = "stellar-de-fra.satoshipay.io:11625"
-HISTORY = "curl -sf https://stellar-history-de-fra.satoshipay.io/{0} -o {1}"
-HOME_DOMAIN = "satoshipay.io"
-
-[[VALIDATORS]]
-NAME = "SatoshiPay Iowa"
-PUBLIC_KEY = "GAK6Z5UVGUVSEK6PEOCAYJISTT5EJBB34PN3NOLEQG2SUKXRVV2F6HZY"
-ADDRESS = "stellar-us-iowa.satoshipay.io:11625"
-HISTORY = "curl -sf https://stellar-history-us-iowa.satoshipay.io/{0} -o {1}"
-HOME_DOMAIN = "satoshipay.io"
-
-[[VALIDATORS]]
-NAME = "SatoshiPay Singapore"
-PUBLIC_KEY = "GBJQUIXUO4XSNPAUT6ODLZUJRV2NPXYASKUBY4G5MYP3M47PCVI55MNT"
-ADDRESS = "stellar-sg-sin.satoshipay.io:11625"
-HISTORY = "curl -sf https://stellar-history-sg-sin.satoshipay.io/{0} -o {1}"
-HOME_DOMAIN = "satoshipay.io"
-
-[[VALIDATORS]]
 NAME = "Blockdaemon Validator 1"
 PUBLIC_KEY = "GAAV2GCVFLNN522ORUYFV33E76VPC22E72S75AQ6MBR5V45Z5DWVPWEU"
 ADDRESS = "stellar-full-validator1.bdnodes.net:11625"
@@ -141,6 +120,27 @@ PUBLIC_KEY = "GBF7QOLFPTHUEDUPTT4ZTULDTA3QXDIO75JHKJN2IYD7YGQLYUTR75BT"
 ADDRESS = "gamma.validator.stellar.creit.tech:11625"
 HISTORY = "curl -sf https://gamma-history.validator.stellar.creit.tech/{0} -o {1}"
 HOME_DOMAIN = "stellar.creit.tech"
+
+[[VALIDATORS]]
+NAME = "OBSRVR Validator 1"
+PUBLIC_KEY = "GDRCZ4IPJR7V3HK4GR45CRTE72SDAOZUF2TDBQ5E5IGWC4KM5TSKU2LS"
+ADDRESS = "core-live-1.nodeswithobsrvr.co:11625"
+HISTORY = "curl -sf https://history-1.nodeswithobsrvr.co/obsrvr-core-1/{0} -o {1}"
+HOME_DOMAIN = "stellar.withobsrvr.com"
+
+[[VALIDATORS]]
+NAME = "OBSRVR Validator 2"
+PUBLIC_KEY = "GA2PU4UGMLSFUXGZATHPTDXXX7FOHBAQC57RSJCQUN72WFKTD6CEPQSF"
+ADDRESS = "core-live-2.nodeswithobsrvr.co:11625"
+HISTORY = "curl -sf https://history-2.nodeswithobsrvr.co/obsrvr-core-2/{0} -o {1}"
+HOME_DOMAIN = "stellar.withobsrvr.com"
+
+[[VALIDATORS]]
+NAME = "OBSRVR Validator 3"
+PUBLIC_KEY = "GACM6GIRMLXBBZIYJXBDTAEYZ2GJP3JJP5G5K4WDPBS6QFHPJNK6S2FB"
+ADDRESS = "core-live-3.nodeswithobsrvr.co:11625"
+HISTORY = "curl -sf https://history-3.nodeswithobsrvr.co/obsrvr-core-3/{0} -o {1}"
+HOME_DOMAIN = "stellar.withobsrvr.com"
 
 [[VALIDATORS]]
 NAME = "FT SCV 1"

--- a/pubnet/stellar-rpc/etc/stellar-captive-core.cfg
+++ b/pubnet/stellar-rpc/etc/stellar-captive-core.cfg
@@ -25,15 +25,15 @@ HOME_DOMAIN = "publicnode.org"
 QUALITY = "HIGH"
 
 [[HOME_DOMAINS]]
-HOME_DOMAIN = "satoshipay.io"
-QUALITY = "HIGH"
-
-[[HOME_DOMAINS]]
 HOME_DOMAIN = "stellar.blockdaemon.com"
 QUALITY = "HIGH"
 
 [[HOME_DOMAINS]]
 HOME_DOMAIN = "stellar.creit.tech"
+QUALITY = "HIGH"
+
+[[HOME_DOMAINS]]
+HOME_DOMAIN = "stellar.withobsrvr.com"
 QUALITY = "HIGH"
 
 [[HOME_DOMAINS]]
@@ -87,27 +87,6 @@ HISTORY = "curl -sf https://lyra-history.publicnode.org/{0} -o {1}"
 HOME_DOMAIN = "publicnode.org"
 
 [[VALIDATORS]]
-NAME = "SatoshiPay Frankfurt"
-PUBLIC_KEY = "GC5SXLNAM3C4NMGK2PXK4R34B5GNZ47FYQ24ZIBFDFOCU6D4KBN4POAE"
-ADDRESS = "stellar-de-fra.satoshipay.io:11625"
-HISTORY = "curl -sf https://stellar-history-de-fra.satoshipay.io/{0} -o {1}"
-HOME_DOMAIN = "satoshipay.io"
-
-[[VALIDATORS]]
-NAME = "SatoshiPay Iowa"
-PUBLIC_KEY = "GAK6Z5UVGUVSEK6PEOCAYJISTT5EJBB34PN3NOLEQG2SUKXRVV2F6HZY"
-ADDRESS = "stellar-us-iowa.satoshipay.io:11625"
-HISTORY = "curl -sf https://stellar-history-us-iowa.satoshipay.io/{0} -o {1}"
-HOME_DOMAIN = "satoshipay.io"
-
-[[VALIDATORS]]
-NAME = "SatoshiPay Singapore"
-PUBLIC_KEY = "GBJQUIXUO4XSNPAUT6ODLZUJRV2NPXYASKUBY4G5MYP3M47PCVI55MNT"
-ADDRESS = "stellar-sg-sin.satoshipay.io:11625"
-HISTORY = "curl -sf https://stellar-history-sg-sin.satoshipay.io/{0} -o {1}"
-HOME_DOMAIN = "satoshipay.io"
-
-[[VALIDATORS]]
 NAME = "Blockdaemon Validator 1"
 PUBLIC_KEY = "GAAV2GCVFLNN522ORUYFV33E76VPC22E72S75AQ6MBR5V45Z5DWVPWEU"
 ADDRESS = "stellar-full-validator1.bdnodes.net:11625"
@@ -148,6 +127,27 @@ PUBLIC_KEY = "GBF7QOLFPTHUEDUPTT4ZTULDTA3QXDIO75JHKJN2IYD7YGQLYUTR75BT"
 ADDRESS = "gamma.validator.stellar.creit.tech:11625"
 HISTORY = "curl -sf https://gamma-history.validator.stellar.creit.tech/{0} -o {1}"
 HOME_DOMAIN = "stellar.creit.tech"
+
+[[VALIDATORS]]
+NAME = "OBSRVR Validator 1"
+PUBLIC_KEY = "GDRCZ4IPJR7V3HK4GR45CRTE72SDAOZUF2TDBQ5E5IGWC4KM5TSKU2LS"
+ADDRESS = "core-live-1.nodeswithobsrvr.co:11625"
+HISTORY = "curl -sf https://history-1.nodeswithobsrvr.co/obsrvr-core-1/{0} -o {1}"
+HOME_DOMAIN = "stellar.withobsrvr.com"
+
+[[VALIDATORS]]
+NAME = "OBSRVR Validator 2"
+PUBLIC_KEY = "GA2PU4UGMLSFUXGZATHPTDXXX7FOHBAQC57RSJCQUN72WFKTD6CEPQSF"
+ADDRESS = "core-live-2.nodeswithobsrvr.co:11625"
+HISTORY = "curl -sf https://history-2.nodeswithobsrvr.co/obsrvr-core-2/{0} -o {1}"
+HOME_DOMAIN = "stellar.withobsrvr.com"
+
+[[VALIDATORS]]
+NAME = "OBSRVR Validator 3"
+PUBLIC_KEY = "GACM6GIRMLXBBZIYJXBDTAEYZ2GJP3JJP5G5K4WDPBS6QFHPJNK6S2FB"
+ADDRESS = "core-live-3.nodeswithobsrvr.co:11625"
+HISTORY = "curl -sf https://history-3.nodeswithobsrvr.co/obsrvr-core-3/{0} -o {1}"
+HOME_DOMAIN = "stellar.withobsrvr.com"
 
 [[VALIDATORS]]
 NAME = "FT SCV 1"


### PR DESCRIPTION
The top-tier transitive quorum on pubnet has changed again. As in #781, the configs are the sorted version of the config from Radar and Atlas.